### PR TITLE
src: adapter: mod: HCIDevReq: Add missing repr(C) attribute

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -54,6 +54,7 @@ impl AddressType {
 }
 
 #[derive(Debug, Copy)]
+#[repr(C)]
 pub struct HCIDevReq {
     pub dev_id: u16,
     pub dev_opt: u32,


### PR DESCRIPTION
The structure `HCIDevReq` is used in a C context.
This patch adds a missing `repr(C)` to it.
If this attribute is omitted, it can happen that `dev_id` and `dev_opt` hold
the values of the respective other member.