### PR TITLE
Fix incomplete ValueNotification parsing

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -55,7 +55,7 @@ impl Debug for BDAddr {
 }
 
 /// A notification sent from a peripheral due to a change in a value.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValueNotification {
     /// The handle that has changed.
     pub handle: u16,

--- a/src/bluez/protocol/att.rs
+++ b/src/bluez/protocol/att.rs
@@ -42,6 +42,18 @@ mod tests {
     }
 
     #[test]
+    fn test_value_notification() {
+        let buf = [27, 46, 0, 165, 17, 5, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(value_notification(&buf), Ok((
+            &[][..],
+            ValueNotification {
+                handle: 46,
+                value: vec![165, 17, 5, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            })
+        ));
+    }
+
+    #[test]
     fn test_error() {
         let buf = [1, 8, 32, 0, 10];
         assert_eq!(characteristics(&buf), Ok((
@@ -108,7 +120,7 @@ named!(pub value_notification<&[u8], ValueNotification>,
     do_parse!(
         _op: tag!(&[ATT_OP_VALUE_NOTIFICATION]) >>
         handle: le_u16 >>
-        value: many1!(le_u8) >>
+        value: many1!(complete!(le_u8)) >>
         (
            ValueNotification { handle, value }
         )


### PR DESCRIPTION
`complete!` needs to wrap `le_u8` in order to prevent an `Incomplete` error once the slice has been fully-traversed. Alternatively, nom 4's `CompleteByteSlice` could be used, but I didn't want to mess with the function signature.

Ref: https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md#dealing-with-incomplete-usage