### PR TITLE
Update nix 0.9->0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -137,10 +132,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -266,7 +262,7 @@ dependencies = [
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,7 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
@@ -361,7 +356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
-"checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+"checksum nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "921f61dc817b379d0834e45d5ec45beaacfae97082090a49c2cf30dcbc30206f"
 "checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "hardware-support"]
 
 [dependencies]
 libc = "0.2.33"
-nix = "0.9.0"
+nix = "0.12.0"
 bytes = "0.4"
 num = "0.1.41"
 log = "0.3.8"

--- a/src/bluez/manager/mod.rs
+++ b/src/bluez/manager/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use libc;
 use libc::{c_void, SOCK_RAW, AF_BLUETOOTH};
+use nix::sys::ioctl::ioctl_param_type;
 use std::mem;
 
 use bluez::util::handle_error;
@@ -14,9 +15,9 @@ struct HciIoctls {}
 // in a private struct to hide
 impl HciIoctls {
     // #define HCIDEVUP	_IOW('H', 201, int)
-    ioctl!(write_int hci_dev_up with b'H', 201);
+    ioctl_write_int!(hci_dev_up, b'H', 201);
     // #define HCIDEVDOWN	_IOW('H', 202, int)
-    ioctl!(write_int hci_dev_down with b'H', 202);
+    ioctl_write_int!(hci_dev_down, b'H', 202);
 }
 
 #[derive(Debug, Copy)]
@@ -92,7 +93,7 @@ impl Manager {
     /// Disables an adapter.
     pub fn down(&self, adapter: &Adapter) -> Result<Adapter> {
         let ctl = self.ctl_fd.lock().unwrap();
-        unsafe { HciIoctls::hci_dev_down(*ctl, adapter.dev_id as i32)? };
+        unsafe { HciIoctls::hci_dev_down(*ctl, adapter.dev_id as ioctl_param_type)? };
         Adapter::from_dev_id(*ctl, adapter.dev_id)
     }
 
@@ -100,7 +101,7 @@ impl Manager {
     pub fn up(&self, adapter: &Adapter) -> Result<Adapter> {
         let ctl = self.ctl_fd.lock().unwrap();
         unsafe {
-            HciIoctls::hci_dev_up(*ctl, adapter.dev_id as i32)?;
+            HciIoctls::hci_dev_up(*ctl, adapter.dev_id as ioctl_param_type)?;
         }
         Adapter::from_dev_id(*ctl, adapter.dev_id)
     }

--- a/src/bluez/util/mod.rs
+++ b/src/bluez/util/mod.rs
@@ -1,14 +1,14 @@
 use nix;
-use nix::Errno;
+use nix::errno::Errno;
 
 use ::Result;
 use Error;
 
 fn errno_to_error(errno: Errno) -> Error {
     match errno {
-        nix::Errno::EPERM => Error::PermissionDenied,
-        nix::Errno::ENODEV => Error::DeviceNotFound,
-        nix::Errno::ENOTCONN => Error::NotConnected,
+        Errno::EPERM => Error::PermissionDenied,
+        Errno::ENODEV => Error::DeviceNotFound,
+        Errno::ENOTCONN => Error::NotConnected,
         _ => Error::Other(errno.to_string())
     }
 }


### PR DESCRIPTION
nix has started adding BT-related constants (e.g. `AddressFamily::Bluetooth`) that would be nice to see utilized here for further cross-platform support. It's still missing a number of items that may prevent a full nix-adoption (e.g., `BTPROTO_HCI`), but this at least pushes us in the right direction.