### PR TITLE
Configurable filter duplicates and active options for scan

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -284,6 +284,16 @@ pub trait Central<P : Peripheral>: Send + Sync + Clone {
     /// to subscribers of `on_event` and will be available via `peripherals()`.
     fn start_scan(&self) -> Result<()>;
 
+    /// Control whether to use active or passive scan mode to find BLE devices. Active mode scan
+    /// notifies advertises about the scan, whereas passive scan only receives data from the
+    /// advertiser. Defaults to use active mode.
+    fn active(&self, enabled: bool);
+
+    /// Control whether to filter multiple advertisements by the same peer device. Receving
+    // can be useful for some applications. E.g. when using scan to collect information from
+    /// beacons that update data frequently. Defaults to filter duplicate advertisements.
+    fn filter_duplicates(&self, enabled: bool);
+
     /// Stops scanning for BLE devices.
     fn stop_scan(&self) -> Result<()>;
 

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -409,7 +409,7 @@ impl Central<Peripheral> for ConnectedAdapter {
     }
 
     fn filter_duplicates(&self, enabled: bool) {
-        self.active.clone().store(enabled, Ordering::Relaxed);
+        self.filter_duplicates.clone().store(enabled, Ordering::Relaxed);
     }
 
     fn start_scan(&self) -> Result<()> {


### PR DESCRIPTION
Allow controlling whether scan is performed in active or passive mode. Similarly allow disabling the filter duplicates state to receive all events when running scan for a longer time.

The API here is

```rust
let central = adapter.connect().unwrap();
central.active(false);
central.filter_duplicates(false);
central.start_scan();
```

This was the simplest one to implement without breaking current usages.

Fixes #19.