### PR TITLE
Make "rumble::bluez::adapter::peripheral" public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "hardware-support"]
 
 [dependencies]
 libc = "0.2.45"
-nix = "0.12.0"
+nix = "0.14.0"
 bytes = "0.4"
 num = "0.1.41"
 log = "0.3.8"

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -1,5 +1,5 @@
 mod acl_stream;
-mod peripheral;
+pub mod peripheral;
 
 use libc;
 use std;


### PR DESCRIPTION
Resolves bug https://github.com/mwylde/rumble/issues/34

Allow expanding the example with "rumble::bluez::adapter::peripheral::Peripheral"