### PR TITLE
Use address type from peripheral properties on connect

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,16 +19,16 @@ impl Default for AddressType {
 impl AddressType {
     pub fn from_u8(v: u8) -> Option<AddressType> {
         match v {
-            0 => Some(AddressType::Public),
-            1 => Some(AddressType::Random),
+            1 => Some(AddressType::Public),
+            2 => Some(AddressType::Random),
             _ => None,
         }
     }
 
     pub fn num(&self) -> u8 {
         match *self {
-            AddressType::Public => 0,
-            AddressType::Random => 1
+            AddressType::Public => 1,
+            AddressType::Random => 2
         }
     }
 }

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -321,7 +321,7 @@ impl Peripheral {
             l2_psm: 0,
             l2_bdaddr: self.address,
             l2_cid: ATT_CID,
-            l2_bdaddr_type: 1,
+            l2_bdaddr_type: self.properties.lock().unwrap().address_type.num() as u8,
         };
 
         // connect to the device


### PR DESCRIPTION
Fixes #30 and #32, and should be a better fix than #39 which hard-codes the address to random type instead of public.